### PR TITLE
Fix CVE-2019-8912

### DIFF
--- a/crypto/af_alg.c
+++ b/crypto/af_alg.c
@@ -121,8 +121,10 @@ static void alg_do_release(const struct af_alg_type *type, void *private)
 
 int af_alg_release(struct socket *sock)
 {
-	if (sock->sk)
+	if (sock->sk) {
 		sock_put(sock->sk);
+		sock->sk = NULL;
+	}
 	return 0;
 }
 EXPORT_SYMBOL_GPL(af_alg_release);


### PR DESCRIPTION
In the Linux kernel through 4.20.11, af_alg_release() in crypto/af_alg.c neglects to set a NULL value for a certain structure member, which leads to a use-after-free in sockfs_setattr.

Patch by Mao Wenan <maowenan@huawei.com>